### PR TITLE
Add UI feedback when submitting a visit.

### DIFF
--- a/src/components/scorecard/scorecard.component.js
+++ b/src/components/scorecard/scorecard.component.js
@@ -10,10 +10,19 @@ module.exports = {
             player: player,
             playerId: player.player_id,
             isCurrentPlayer: player.is_current_player,
+            submitClass: null,
             totalScore: 0,
             currentDart: 1,
             isSubmitted: true,
             isBusted: false
+        }
+    },
+
+    onInput(input) {
+        if (input.submitting && this.state.isCurrentPlayer) {
+            this.state.submitClass = "submitting";
+        } else {
+            this.state.submitClass = null;
         }
     },
     

--- a/src/components/scorecard/scorecard.marko
+++ b/src/components/scorecard/scorecard.marko
@@ -17,7 +17,7 @@
       </tr>
       <tr>
         <td colspan="3">
-          <div class="total-score">${state.totalScore}</div>
+          <div class=["total-score", state.submitClass]>${state.totalScore}</div>
         </td>
       </tr>
     </tbody>

--- a/src/components/scorecard/scorecard.style.less
+++ b/src/components/scorecard/scorecard.style.less
@@ -13,3 +13,7 @@ table {
     .font-24;
     font-weight: 700;
 }
+.total-score.submitting {
+    background-color: @dart-single;
+    color: white;
+}

--- a/src/components/scorecard/scorecard.style.less
+++ b/src/components/scorecard/scorecard.style.less
@@ -12,8 +12,11 @@ table {
     .text-center;
     .font-24;
     font-weight: 700;
+    transition: 40ms;
 }
 .total-score.submitting {
     background-color: @dart-single;
     color: white;
+    transition: 750ms;
+    transition-delay: 100ms
 }

--- a/src/pages/leg/components/leg/leg.marko
+++ b/src/pages/leg/components/leg/leg.marko
@@ -8,7 +8,7 @@
         <for|player| of=input.leg_players>
           <tr>
             <scorecard-header key=`player-${player.player_id}` player=player name=input.players[player.player_id].name/>
-            <scorecard key="players[]" legId=state.legId player=player on-possible-throw("onPossibleThrow") on-score-change("onScoreChange") on-player-busted("onPlayerBusted") on-leg-finished("onLegFinished") on-undo-throw("onUndoThrow")/>
+            <scorecard key="players[]" legId=state.legId submitting=state.submitting player=player on-possible-throw("onPossibleThrow") on-score-change("onScoreChange") on-player-busted("onPlayerBusted") on-leg-finished("onLegFinished") on-undo-throw("onUndoThrow")/>
             </tr>
         </for>
       </if>
@@ -20,7 +20,7 @@
         </tr>
         <tr>
           <for|player| of=input.leg_players>
-            <scorecard key="players[]" legId=state.legId player=player on-possible-throw("onPossibleThrow") on-score-change("onScoreChange") on-player-busted("onPlayerBusted") on-leg-finished("onLegFinished") on-undo-throw("onUndoThrow")/>
+            <scorecard key="players[]" legId=state.legId submitting=state.submitting player=player on-possible-throw("onPossibleThrow") on-score-change("onScoreChange") on-player-busted("onPlayerBusted") on-leg-finished("onLegFinished") on-undo-throw("onUndoThrow")/>
           </for>
         </tr>
       </else>


### PR DESCRIPTION
I've experienced that kcapp is sometimes slow to submit a visit, leaving me wondering if I didn't hit enter enough times. This PR tries to solve that ambiguity by making the total score white-on-black when the leg is being submitted.

Caveats:
* This is only for the marko leg template, which means it doesn't work on 9-dart shootout.
* `this.state.submitting` in the leg component is set even if it's still pending confirmation from the user for a checkout or bust.