### PR TITLE
Fix kcapp-bot API URL in docker setups #135

### DIFF
--- a/routes/lib/socketio_handler.js
+++ b/routes/lib/socketio_handler.js
@@ -120,7 +120,7 @@ module.exports = (io, app) => {
                                     // TODO Make sure this works correctly
                                     debug(`[${legId}] Adding bot ${player.id}/${player.name}`);
                                     const config = legPlayers[id].bot_config;
-                                    const bot = require('kcapp-bot/kcapp-bot')(player.id, "localhost", 3000);
+                                    const bot = require('kcapp-bot/kcapp-bot')(player.id, "localhost", 3000, `${app.locals.kcapp.api}`);
                                     if (config && config.skill_level === 0) {
                                         bot.replayLeg(legId, config.player_id);
                                     } else {


### PR DESCRIPTION
Allows kcapp-bot to use a non-standard API URL set by the environment variable `KCAPP_API`, so mock-based practice works in Docker setups.