### PR TITLE
Added choosing a starting score in practice

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "debug": "^4.3.2",
                 "dissolve": "^0.3.3",
                 "express": "^5.0.0-alpha.8",
-                "kcapp-bot": "github:kcapp/bot#d47d13d9cdbc80a282ed2c0e8072b7b937088239",
+                "kcapp-bot": "file:../bot",
                 "kcapp-sio-client": "github:kcapp/kcapp-sio-client",
                 "lasso": "^3.4.3",
                 "lasso-less": "^4.0.1",
@@ -43,6 +43,16 @@
             },
             "devDependencies": {
                 "cross-env": "^7.0.3"
+            }
+        },
+        "../bot": {
+            "name": "kcapp-bot",
+            "version": "0.0.1",
+            "dependencies": {
+                "axios": "^0.26.1",
+                "debug": "^4.3.4",
+                "decache": "^4.6.1",
+                "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1822,14 +1832,6 @@
             "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
             "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
         },
-        "node_modules/callsite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001312",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -2359,14 +2361,6 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "node_modules/decache": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
-            "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
-            "dependencies": {
-                "callsite": "^1.0.0"
-            }
         },
         "node_modules/decode-uri-component": {
             "version": "0.2.0",
@@ -5011,23 +5005,8 @@
             }
         },
         "node_modules/kcapp-bot": {
-            "version": "0.0.1",
-            "resolved": "git+ssh://git@github.com/kcapp/bot.git#d47d13d9cdbc80a282ed2c0e8072b7b937088239",
-            "integrity": "sha512-ricIMqEqhYymrUGz89kkGsVnOvFMRbnE9H69VgNhszbJhVMdLwaNjoSocENyj3Aa7ne3qeO7OYQxDNsrtxrJPg==",
-            "dependencies": {
-                "axios": "^0.26.1",
-                "debug": "^4.3.4",
-                "decache": "^4.6.1",
-                "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
-            }
-        },
-        "node_modules/kcapp-bot/node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.8"
-            }
+            "resolved": "../bot",
+            "link": true
         },
         "node_modules/kcapp-sio-client": {
             "version": "0.0.2",
@@ -9693,11 +9672,6 @@
             "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
             "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
         },
-        "callsite": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
-        },
         "caniuse-lite": {
             "version": "1.0.30001312",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -10136,14 +10110,6 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
-            }
-        },
-        "decache": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
-            "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
-            "requires": {
-                "callsite": "^1.0.0"
             }
         },
         "decode-uri-component": {
@@ -12200,24 +12166,12 @@
             }
         },
         "kcapp-bot": {
-            "version": "git+ssh://git@github.com/kcapp/bot.git#d47d13d9cdbc80a282ed2c0e8072b7b937088239",
-            "integrity": "sha512-ricIMqEqhYymrUGz89kkGsVnOvFMRbnE9H69VgNhszbJhVMdLwaNjoSocENyj3Aa7ne3qeO7OYQxDNsrtxrJPg==",
-            "from": "kcapp-bot@github:kcapp/bot#d47d13d9cdbc80a282ed2c0e8072b7b937088239",
+            "version": "file:../bot",
             "requires": {
                 "axios": "^0.26.1",
                 "debug": "^4.3.4",
                 "decache": "^4.6.1",
                 "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
-            },
-            "dependencies": {
-                "axios": {
-                    "version": "0.26.1",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.8"
-                    }
-                }
             }
         },
         "kcapp-sio-client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "debug": "^4.3.2",
                 "dissolve": "^0.3.3",
                 "express": "^5.0.0-alpha.8",
-                "kcapp-bot": "file:../bot",
+                "kcapp-bot": "github:kcapp/bot#4a7512fcec16ec15882fdbb19cd88c8adab24a44",
                 "kcapp-sio-client": "github:kcapp/kcapp-sio-client",
                 "lasso": "^3.4.3",
                 "lasso-less": "^4.0.1",
@@ -43,16 +43,6 @@
             },
             "devDependencies": {
                 "cross-env": "^7.0.3"
-            }
-        },
-        "../bot": {
-            "name": "kcapp-bot",
-            "version": "0.0.1",
-            "dependencies": {
-                "axios": "^0.26.1",
-                "debug": "^4.3.4",
-                "decache": "^4.6.1",
-                "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1832,6 +1822,14 @@
             "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
             "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
         },
+        "node_modules/callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001312",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -2361,6 +2359,14 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/decache": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
+            "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
+            "dependencies": {
+                "callsite": "^1.0.0"
+            }
         },
         "node_modules/decode-uri-component": {
             "version": "0.2.0",
@@ -5005,8 +5011,23 @@
             }
         },
         "node_modules/kcapp-bot": {
-            "resolved": "../bot",
-            "link": true
+            "version": "0.0.1",
+            "resolved": "git+ssh://git@github.com/kcapp/bot.git#4a7512fcec16ec15882fdbb19cd88c8adab24a44",
+            "integrity": "sha512-fGJr8I3Jnp/hNVZtzGP0LGhgKj8nBhYLc4GYtKudgSvNGJkue+FaRQjNDdz2ylr3Q+twFveLSv+JtUuUb9xbAQ==",
+            "dependencies": {
+                "axios": "^0.26.1",
+                "debug": "^4.3.4",
+                "decache": "^4.6.1",
+                "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
+            }
+        },
+        "node_modules/kcapp-bot/node_modules/axios": {
+            "version": "0.26.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+            "dependencies": {
+                "follow-redirects": "^1.14.8"
+            }
         },
         "node_modules/kcapp-sio-client": {
             "version": "0.0.2",
@@ -9672,6 +9693,11 @@
             "resolved": "https://registry.npmjs.org/callbackify/-/callbackify-1.1.0.tgz",
             "integrity": "sha1-0qNphtKKppcUUmwREgm+65l50x4="
         },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ=="
+        },
         "caniuse-lite": {
             "version": "1.0.30001312",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -10110,6 +10136,14 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 }
+            }
+        },
+        "decache": {
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/decache/-/decache-4.6.1.tgz",
+            "integrity": "sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==",
+            "requires": {
+                "callsite": "^1.0.0"
             }
         },
         "decode-uri-component": {
@@ -12166,12 +12200,24 @@
             }
         },
         "kcapp-bot": {
-            "version": "file:../bot",
+            "version": "git+ssh://git@github.com/kcapp/bot.git#4a7512fcec16ec15882fdbb19cd88c8adab24a44",
+            "integrity": "sha512-fGJr8I3Jnp/hNVZtzGP0LGhgKj8nBhYLc4GYtKudgSvNGJkue+FaRQjNDdz2ylr3Q+twFveLSv+JtUuUb9xbAQ==",
+            "from": "kcapp-bot@github:kcapp/bot#4a7512fcec16ec15882fdbb19cd88c8adab24a44",
             "requires": {
                 "axios": "^0.26.1",
                 "debug": "^4.3.4",
                 "decache": "^4.6.1",
                 "kcapp-sio-client": "github:kcapp/kcapp-sio-client"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.26.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+                    "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+                    "requires": {
+                        "follow-redirects": "^1.14.8"
+                    }
+                }
             }
         },
         "kcapp-sio-client": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "debug": "^4.3.2",
         "dissolve": "^0.3.3",
         "express": "^5.0.0-alpha.8",
-        "kcapp-bot": "file:../bot",
+        "kcapp-bot": "github:kcapp/bot#4a7512fcec16ec15882fdbb19cd88c8adab24a44",
         "kcapp-sio-client": "github:kcapp/kcapp-sio-client",
         "lasso": "^3.4.3",
         "lasso-less": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "debug": "^4.3.2",
         "dissolve": "^0.3.3",
         "express": "^5.0.0-alpha.8",
-        "kcapp-bot": "github:kcapp/bot#d47d13d9cdbc80a282ed2c0e8072b7b937088239",
+        "kcapp-bot": "file:../bot",
         "kcapp-sio-client": "github:kcapp/kcapp-sio-client",
         "lasso": "^3.4.3",
         "lasso-less": "^4.0.1",

--- a/routes/lib/socketio_handler.js
+++ b/routes/lib/socketio_handler.js
@@ -122,7 +122,7 @@ module.exports = (io, app) => {
                                     const config = legPlayers[id].bot_config;
                                     const bot = require('kcapp-bot/kcapp-bot')(player.id, "localhost", 3000);
                                     if (config && config.skill_level === 0) {
-                                        bot.replayLeg(legId, config.player_id);
+                                        bot.replayLeg(legId, config.player_id, config.starting_score);
                                     } else {
                                         const botSkill = config ? skill.fromInt(config.skill_level) : skill.MEDIUM;
                                         bot.playLeg(legId, botSkill);

--- a/src/pages/practice/components/practice/practice.component.js
+++ b/src/pages/practice/components/practice/practice.component.js
@@ -18,7 +18,7 @@ module.exports = {
             officeId: 0,
             venues: input.venues,
             options: {
-                starting_score: 301,
+                starting_score: 501,
                 game_type: 1,
                 game_mode: 1,
                 stake: null,
@@ -176,7 +176,11 @@ module.exports = {
 
         var botPlayerConfig = {};
         if (this.state.bot.type == this.state.skill.TYPE_MOCK) {
-            botPlayerConfig[bot.id] = { player_id: this.state.bot.mock_player_id, skill_level: 0 };
+            botPlayerConfig[bot.id] = {
+                player_id: this.state.bot.mock_player_id,
+                skill_level: 0,
+                starting_score: this.state.options.starting_score
+            }
         } else {
             botPlayerConfig[bot.id] = { player_id: null, skill_level: this.state.bot.skill };
         }

--- a/src/pages/practice/components/practice/practice.component.js
+++ b/src/pages/practice/components/practice/practice.component.js
@@ -182,7 +182,11 @@ module.exports = {
                 starting_score: this.state.options.starting_score
             }
         } else {
-            botPlayerConfig[bot.id] = { player_id: null, skill_level: this.state.bot.skill };
+            botPlayerConfig[bot.id] = {
+                player_id: null,
+                skill_level: this.state.bot.skill,
+                starting_score: this.state.options.starting_score
+            }
         }
         var players = this.state.selected.map(player => player.id);
         players.push(bot.id);

--- a/src/pages/practice/components/practice/practice.marko
+++ b/src/pages/practice/components/practice/practice.marko
@@ -74,7 +74,7 @@
     </div>
     <div class="block-container-with-header">
       <game-option-selector values=[input.types[0]] enabled=false options=state.options key="game-type" label="Match Type" attribute="game_type" defaultValue=state.options.game_type on-value-changed("onGameTypeChanged")/>
-      <game-option-selector values=[input.scores[1]] options=state.options key="starting-score" label="Starting Score" attribute="starting_score" defaultValue=state.options.starting_score/>
+      <game-option-selector values=input.scores options=state.options key="starting-score" label="Starting Score" attribute="starting_score" defaultValue=state.options.starting_score/>
       <game-option-selector values=[input.modes[0]] options=state.options key="game-mode" label="Match Mode" attribute="game_mode" defaultValue=state.options.game_mode/>
       <game-option-selector values=state.venues options=state.options key="venue" label="Venue" attribute="venue_id" addNull=true/>
       <button class="btn btn-primary" type="submit" on-click("newGame")>Start</button>


### PR DESCRIPTION
Allow choosing a starting score (301, 501, 701) for a practice match.

These code changes assume that the BotConfig in the API has an additional value for the starting score, which isn't yet implemented. I don't feel sure about working with and migrating a database, so it would be good if someone else could take care of this.
~It currently also has kcapp-bot as a local directory in the package.json for development reasons. When releasing or https://github.com/kcapp/bot/pull/7 is merged, this should obviously be changed.~