### PR TITLE
Fixed fetching a mock leg with an incorrect starting score

### DIFF
--- a/routes/lib/socketio_handler.js
+++ b/routes/lib/socketio_handler.js
@@ -121,7 +121,7 @@ module.exports = (io, app) => {
                                     const config = legPlayers[id].bot_config;
                                     const bot = require('kcapp-bot/kcapp-bot')(player.id, "localhost", 3000, `${app.locals.kcapp.api}`);
                                     if (config && config.skill_level === 0) {
-                                        bot.replayLeg(legId, config.player_id, legPlayers[id].starting_score);
+                                        bot.replayLeg(legId, config.player_id, legPlayers[id].current_score);
                                     } else {
                                         const botSkill = config ? skill.fromInt(config.skill_level) : skill.MEDIUM;
                                         bot.playLeg(legId, botSkill);


### PR DESCRIPTION
The `legPlayers[id]` object doesn't seem to contain a variable named `starting_score`, but there is `current_score` which at the beginning of a leg contains the starting score.