### PR TITLE
Label first-9 average separately on stats cards and tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ A preview of major changes can be found in the Wiki ([Latest Changes](https://gi
 - Undo leg finish by clicking `Backspace` on start of next leg
 - Darts thrown in previous vist is now remembered when going back
 
+#### Fixed
+- Three Dart Avg. on stats cards and tables now indicates which value is overall vs first 9 (#153)
+
 ## [2.10.0] - 2026-03-12
 #### Feature
 - Player progression is now reworked to group legs into buckets for better comparsion

--- a/src/components/player-statistics-card/player-statistics-card.marko
+++ b/src/components/player-statistics-card/player-statistics-card.marko
@@ -74,7 +74,7 @@ $ const matchType = leg.leg_type.id || match.match_type.id;
         </div>
       </div>
       <if(matchType == type.X01 || matchType == type.X01HANDICAP)>
-        <statistics-row heading="Three Dart Avg." value=`${statistic.three_dart_avg.toFixed(2)} / ${statistic.first_nine_three_dart_avg.toFixed(2)}`/>
+        <statistics-row heading="Three Dart Avg. / First 9" value=`${statistic.three_dart_avg.toFixed(2)} / ${statistic.first_nine_three_dart_avg.toFixed(2)}`/>
         $ var accuracy_20 = statistic.accuracy_20 === null ? "-" : statistic.accuracy_20.toFixed(2);
         $ var accuracy_19 = statistic.accuracy_19 === null ? "-" : statistic.accuracy_19.toFixed(2);
         <statistics-row heading="Accuracy Overall / 20 / 19" value=`${statistic.accuracy_overall.toFixed(2)} / ${accuracy_20} / ${accuracy_19}`/>

--- a/src/pages/leaderboard/components/leaderboard/components/leaderboard-table/leaderboard-table.marko
+++ b/src/pages/leaderboard/components/leaderboard/components/leaderboard-table/leaderboard-table.marko
@@ -8,7 +8,7 @@ import Table from "../../../../../../components/statistics-table/statistics-tabl
             <th class="text-center">Played</th>
             <th class="text-center">Won</th>
             <th class="text-center" style="width: 15%">Win %</th>
-            <th class="text-center" style="width: 50%">Three Dart Avg.</th>
+            <th class="text-center" style="width: 50%" title="3 Dart Avg. / First 9 Three Dart Avg.">Three Dart Avg.</th>
             <th class="text-center">Checkout</th>
             <th class="text-center">60s+</th>
             <th class="text-center">100s+</th>

--- a/src/pages/player/components/player/components/tab-statistics/tab-statistics.marko
+++ b/src/pages/player/components/player/components/tab-statistics/tab-statistics.marko
@@ -15,7 +15,7 @@ $ var moment = require('moment');
                     </td>
                     <if(input.type == types.X01 || input.type == types.X01HANDICAP)>
                         <td style="width: 25%;">
-                            <statistics-card label="Three Dart Avg." value=`${(input.statistics.three_dart_avg).toFixed(2)} / ${(input.statistics.first_nine_three_dart_avg).toFixed(2)}` icon="fas fa-circle-notch"/>
+                            <statistics-card label="Three Dart Avg. / First 9" value=`${(input.statistics.three_dart_avg).toFixed(2)} / ${(input.statistics.first_nine_three_dart_avg).toFixed(2)}` icon="fas fa-circle-notch"/>
                         </td>
                         <td style="width: 25%;">
                             <statistics-card label="Checkout %" value=`${input.statistics.checkout_percentage ? input.statistics.checkout_percentage.toFixed(2) : "-"} %` icon="fas fa-star"/>
@@ -183,7 +183,7 @@ $ var moment = require('moment');
                 <th class="text-center" style='width: 18%;'>Start Time</th>
                 <th class="text-center" style='width: 30%;'>Players</th>
                 <if(input.type == types.X01 || input.type == types.X01HANDICAP)>
-                    <th class="text-center">Three Dart Avg.</th>
+                    <th class="text-center" title="3 Dart Avg. / First 9 Three Dart Avg.">Three Dart Avg.</th>
                     <th class="text-center">Checkout</th>
                     <th class="text-center">Overall</th>
                     <th class="text-center">20s</th>

--- a/src/pages/statistics/components/statistics/components/statistics-table-x01/statistics-table-x01.marko
+++ b/src/pages/statistics/components/statistics/components/statistics-table-x01/statistics-table-x01.marko
@@ -13,7 +13,7 @@ import Table from "../../../../../../components/statistics-table/statistics-tabl
             <th class="text-center">Played</th>
             <th class="text-center">Won</th>
             <th class="text-right">Win %</th>
-            <th class="text-center">Three Dart Avg.</th>
+            <th class="text-center" title="3 Dart Avg. / First 9 Three Dart Avg.">Three Dart Avg.</th>
             <th class="text-right">Checkout</th>
             <th class="text-right">60s+</th>
             <th class="text-right">100s+</th>


### PR DESCRIPTION
The Three Dart Avg. cell shows two slash-separated numbers (overall / first 9) without indicating which is which. On the stats cards there is plenty of room, so include "/ First 9" in the heading directly. On the denser tables, add a title= tooltip matching the convention already in use on tournament-overview-table.

Closes #153